### PR TITLE
GitHub ActionsのCIを追加しました

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+
+      - name: Run tests via Makefile
+        run: make testt


### PR DESCRIPTION
## 変更内容

GitHub ActionsのCIを追加しました。

## なぜこの変更を？

自動テストが必要だったので追加しました。

## 備考

Makefile 側でテストが実行されるように調整中のため、今後はそちらに統一する可能性もあります。
